### PR TITLE
interruption result with max ct values when secure as backup

### DIFF
--- a/csa-runner-app/src/main/java/com/farao_community/farao/swe_csa/app/dichotomy/DichotomyRunner.java
+++ b/csa-runner-app/src/main/java/com/farao_community/farao/swe_csa/app/dichotomy/DichotomyRunner.java
@@ -118,7 +118,7 @@ public class DichotomyRunner {
             return new Pair<>(noCtStepResult.getRaoResult(), Status.FINISHED_SECURE);
         } else {
             if (interruptionService.getTasksToInterrupt().remove(csaRequest.getId())) {
-                businessLogger.info("Interruption asked for task {}, best results at current time will be returned", csaRequest.getId());
+                businessLogger.info("Interruption asked for task {}, before any secure situation is found", csaRequest.getId());
                 return new Pair<>(null, Status.FINISHED_UNSECURE);
             }
 
@@ -151,6 +151,7 @@ public class DichotomyRunner {
                 index.addPtEsDichotomyStepResult(ctPtEsUpperBound, maxCtStepResult);
                 index.addFrEsDichotomyStepResult(0, noCtStepResult);
                 index.addFrEsDichotomyStepResult(ctFrEsUpperBound, maxCtStepResult);
+                index.setBestValidDichotomyStepResult(maxCtStepResult);
                 return processDichotomy(csaRequest, raoParameters, raoParametersUrl, network, crac, initialVariant, networkShifter, index);
             }
         }
@@ -161,7 +162,7 @@ public class DichotomyRunner {
         boolean timeout = false;
         while (index.exitConditionIsNotMetForPtEs() || index.exitConditionIsNotMetForFrEs()) {
             if (interruptionService.getTasksToInterrupt().remove(csaRequest.getId())) {
-                businessLogger.info("Interruption asked for task {}, best results at current time will be returned", csaRequest.getId());
+                businessLogger.info("Interruption asked for task {}, best secure situation at current time will be returned", csaRequest.getId());
                 interrupted = true;
                 break;
             }
@@ -208,6 +209,7 @@ public class DichotomyRunner {
             }
 
             RaoResult raoResult = index.getBestValidDichotomyStepResult().getRaoResult();
+            // TODO MBR : check if we need to rerun angle monitoring here
             raoResult = updateRaoResultWithVoltageMonitoring(network, crac, raoResult, raoParameters);
             RaoResultWithCounterTradeRangeActions raoResultWithRangeAction = updateRaoResultWithCounterTradingRAs(network, crac, index, raoResult);
             fileExporter.saveRaoResultInArtifact(csaRequest.getResultsUri(), raoResultWithRangeAction, crac);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Corrected a typo in a method name related to counter trade range actions
- **Improvements**
    - Enhanced logging messages for better clarity during task interruptions
    - Improved tracking of optimal results during the dichotomy process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->