### PR TITLE
CSA requst API with glsk file and two cracs one for each SWE border

### DIFF
--- a/csa-runner-api/src/main/java/com/farao_community/farao/swe_csa/api/resource/CsaRequest.java
+++ b/csa-runner-api/src/main/java/com/farao_community/farao/swe_csa/api/resource/CsaRequest.java
@@ -14,17 +14,24 @@ public class CsaRequest {
     private final String id;
     private String businessTimestamp;
     private String gridModelUri;
-    private String cracFileUri;
+    private String glskUri;
+    private String ptEsCracFileUri;
+    private String frEsCracFileUri;
 
     @JsonCreator
     public CsaRequest(@JsonProperty("id") String id,
                       @JsonProperty("businessTimestamp") String businessTimestamp,
                       @JsonProperty("gridModelUri") String gridModelUri,
-                      @JsonProperty("cracFileUri") String cracFileUri) {
+                      @JsonProperty("glskUri") String glskUri,
+                      @JsonProperty("ptEsCracFileUri") String ptEsCracFileUri,
+                      @JsonProperty("frEsCracFileUri") String frEsCracFileUri) {
         this.id = id;
         this.businessTimestamp = businessTimestamp;
         this.gridModelUri = gridModelUri;
-        this.cracFileUri = cracFileUri;
+        this.glskUri = glskUri;
+        this.ptEsCracFileUri = ptEsCracFileUri;
+        this.frEsCracFileUri = frEsCracFileUri;
+
     }
 
     public String getId() {
@@ -47,12 +54,28 @@ public class CsaRequest {
         this.gridModelUri = gridModelUri;
     }
 
-    public String getCracFileUri() {
-        return cracFileUri;
+    public String getPtEsCracFileUri() {
+        return ptEsCracFileUri;
     }
 
-    public void setCracFileUri(String cracFileUri) {
-        this.cracFileUri = cracFileUri;
+    public String getFrEsCracFileUri() {
+        return frEsCracFileUri;
+    }
+
+    public void setPtEsCracFileUri(String ptEsCracFileUri) {
+        this.ptEsCracFileUri = ptEsCracFileUri;
+    }
+
+    public void setFrEsCracFileUri(String frEsCracFileUri) {
+        this.frEsCracFileUri = frEsCracFileUri;
+    }
+
+    public String getGlskUri() {
+        return glskUri;
+    }
+
+    public void setGlskUri(String glskUri) {
+        this.glskUri = glskUri;
     }
 
     @Override
@@ -72,11 +95,11 @@ public class CsaRequest {
             return false;
         }
         CsaRequest other = (CsaRequest) obj;
-        return this.id.equals(other.id) && this.businessTimestamp.equals(other.businessTimestamp) && this.gridModelUri.equals(other.gridModelUri) && this.cracFileUri.equals(other.cracFileUri);
+        return this.id.equals(other.id) && this.businessTimestamp.equals(other.businessTimestamp) && this.gridModelUri.equals(other.gridModelUri) && this.glskUri.equals(other.glskUri) && this.ptEsCracFileUri.equals(other.ptEsCracFileUri) && this.frEsCracFileUri.equals(other.frEsCracFileUri);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, businessTimestamp, gridModelUri, cracFileUri);
+        return Objects.hash(id, businessTimestamp, gridModelUri, glskUri, ptEsCracFileUri, frEsCracFileUri);
     }
 }

--- a/csa-runner-api/src/main/java/com/farao_community/farao/swe_csa/api/resource/CsaRequest.java
+++ b/csa-runner-api/src/main/java/com/farao_community/farao/swe_csa/api/resource/CsaRequest.java
@@ -6,6 +6,8 @@ import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Type;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import java.util.Objects;
+
 @Type("csa-rao-request")
 public class CsaRequest {
     @Id
@@ -13,19 +15,16 @@ public class CsaRequest {
     private String businessTimestamp;
     private String gridModelUri;
     private String cracFileUri;
-    private String resultsUri;
 
     @JsonCreator
     public CsaRequest(@JsonProperty("id") String id,
                       @JsonProperty("businessTimestamp") String businessTimestamp,
                       @JsonProperty("gridModelUri") String gridModelUri,
-                      @JsonProperty("cracFileUri") String cracFileUri,
-                      @JsonProperty("resultsUri") String resultsUri) {
+                      @JsonProperty("cracFileUri") String cracFileUri) {
         this.id = id;
         this.businessTimestamp = businessTimestamp;
         this.gridModelUri = gridModelUri;
         this.cracFileUri = cracFileUri;
-        this.resultsUri = resultsUri;
     }
 
     public String getId() {
@@ -56,16 +55,28 @@ public class CsaRequest {
         this.cracFileUri = cracFileUri;
     }
 
-    public String getResultsUri() {
-        return resultsUri;
-    }
-
-    public void setResultsUri(String resultsUri) {
-        this.resultsUri = resultsUri;
-    }
-
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        CsaRequest other = (CsaRequest) obj;
+        return this.id.equals(other.id) && this.businessTimestamp.equals(other.businessTimestamp) && this.gridModelUri.equals(other.gridModelUri) && this.cracFileUri.equals(other.cracFileUri);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, businessTimestamp, gridModelUri, cracFileUri);
     }
 }

--- a/csa-runner-api/src/test/java/com/farao_community/farao/swe_csa/api/JsonApiConverterTest.java
+++ b/csa-runner-api/src/test/java/com/farao_community/farao/swe_csa/api/JsonApiConverterTest.java
@@ -35,7 +35,8 @@ class JsonApiConverterTest {
         assertEquals("id", request.getId());
         assertEquals("2023-08-08T15:30:00Z", request.getBusinessTimestamp());
         assertEquals("https://cds/gridModelUri.signed.url", request.getGridModelUri());
-        assertEquals("https://cds/cracFileUri.signed.url", request.getCracFileUri());
+        assertEquals("https://cds/ptEsCracFileUri.signed.url", request.getPtEsCracFileUri());
+        assertEquals("https://cds/frEsCracFileUri.signed.url", request.getFrEsCracFileUri());
     }
 
     @Test

--- a/csa-runner-api/src/test/java/com/farao_community/farao/swe_csa/api/JsonApiConverterTest.java
+++ b/csa-runner-api/src/test/java/com/farao_community/farao/swe_csa/api/JsonApiConverterTest.java
@@ -36,7 +36,6 @@ class JsonApiConverterTest {
         assertEquals("2023-08-08T15:30:00Z", request.getBusinessTimestamp());
         assertEquals("https://cds/gridModelUri.signed.url", request.getGridModelUri());
         assertEquals("https://cds/cracFileUri.signed.url", request.getCracFileUri());
-        assertEquals("https://cds/resultsUri.signed.url", request.getResultsUri());
     }
 
     @Test

--- a/csa-runner-api/src/test/java/com/farao_community/farao/swe_csa/api/resource/CsaRequestTest.java
+++ b/csa-runner-api/src/test/java/com/farao_community/farao/swe_csa/api/resource/CsaRequestTest.java
@@ -21,13 +21,11 @@ class CsaRequestTest {
         String businessTimestamp = "2023-08-08T15:30:00Z";
         String gridModelUri = "https://example.com/gridModel";
         String cracFileUri = "https://example.com/crac";
-        String resultsUri = "https://example.com/results";
 
-        CsaRequest request = new CsaRequest(id, businessTimestamp, gridModelUri, cracFileUri, resultsUri);
+        CsaRequest request = new CsaRequest(id, businessTimestamp, gridModelUri, cracFileUri);
         assertEquals(id, request.getId());
         assertEquals(businessTimestamp, request.getBusinessTimestamp());
         assertEquals(gridModelUri, request.getGridModelUri());
         assertEquals(cracFileUri, request.getCracFileUri());
-        assertEquals(resultsUri, request.getResultsUri());
     }
 }

--- a/csa-runner-api/src/test/java/com/farao_community/farao/swe_csa/api/resource/CsaRequestTest.java
+++ b/csa-runner-api/src/test/java/com/farao_community/farao/swe_csa/api/resource/CsaRequestTest.java
@@ -9,6 +9,7 @@ package com.farao_community.farao.swe_csa.api.resource;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * @author mohamed.ben-rejeb {@literal <mohamed.ben-rejeb at rte-france.com>}
@@ -20,12 +21,31 @@ class CsaRequestTest {
         String id = "sampleId";
         String businessTimestamp = "2023-08-08T15:30:00Z";
         String gridModelUri = "https://example.com/gridModel";
-        String cracFileUri = "https://example.com/crac";
+        String glskUri = "https://example.com/glsk";
+        String ptEsCracFileUri = "https://example.com/ptEsCrac";
+        String frEsCracFileUri = "https://example.com/frEsCrac";
 
-        CsaRequest request = new CsaRequest(id, businessTimestamp, gridModelUri, cracFileUri);
+        CsaRequest request = new CsaRequest(id, businessTimestamp, gridModelUri, glskUri, ptEsCracFileUri, frEsCracFileUri);
         assertEquals(id, request.getId());
         assertEquals(businessTimestamp, request.getBusinessTimestamp());
         assertEquals(gridModelUri, request.getGridModelUri());
-        assertEquals(cracFileUri, request.getCracFileUri());
+        assertEquals(glskUri, request.getGlskUri());
+        assertEquals(ptEsCracFileUri, request.getPtEsCracFileUri());
+        assertEquals(frEsCracFileUri, request.getFrEsCracFileUri());
     }
+
+    @Test
+    void testEqualsAndHashCode() {
+        CsaRequest request1 = new CsaRequest("1", "2025-03-11T12:00:00Z", "gridUri", "glskUri", "ptEsUri", "frEsUri");
+        CsaRequest request2 = new CsaRequest("1", "2025-03-11T12:00:00Z", "gridUri", "glskUri", "ptEsUri", "frEsUri");
+        CsaRequest request3 = new CsaRequest("2", "2025-03-11T12:00:00Z", "gridUri", "glskUri", "ptEsUri", "frEsUri");
+
+        assertEquals(request1, request2);
+        assertEquals(request1.hashCode(), request2.hashCode());
+        assertNotEquals(request1, request3);
+        assertNotEquals(request1.hashCode(), request3.hashCode());
+        assertNotEquals(null, request1);
+        assertNotEquals("some string", request1);
+    }
+
 }

--- a/csa-runner-api/src/test/java/com/farao_community/farao/swe_csa/api/resource/RaoRunnerLogsModelTest.java
+++ b/csa-runner-api/src/test/java/com/farao_community/farao/swe_csa/api/resource/RaoRunnerLogsModelTest.java
@@ -10,6 +10,7 @@ package com.farao_community.farao.swe_csa.api.resource;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author Jean-Pierre Arnould {@literal <jean-pierre.arnould at rte-france.com>}
@@ -27,6 +28,6 @@ class RaoRunnerLogsModelTest {
         assertEquals("timestamp", raoRunnerLogsModel.getTimestamp());
         assertEquals("message", raoRunnerLogsModel.getMessage());
         assertEquals("serviceName", raoRunnerLogsModel.getServiceName());
-        assertEquals(null, raoRunnerLogsModel.getEventPrefix());
+        assertNull(raoRunnerLogsModel.getEventPrefix());
     }
 }

--- a/csa-runner-api/src/test/resources/csaRequestMessage.json
+++ b/csa-runner-api/src/test/resources/csaRequestMessage.json
@@ -5,7 +5,10 @@
     "attributes": {
       "businessTimestamp": "2023-08-08T15:30:00Z",
       "gridModelUri": "https://cds/gridModelUri.signed.url",
-      "cracFileUri": "https://cds/cracFileUri.signed.url"
+      "glskUri": "https://cds/glskUri.signed.url",
+      "ptEsCracFileUri": "https://cds/ptEsCracFileUri.signed.url",
+      "frEsCracFileUri": "https://cds/frEsCracFileUri.signed.url"
+
     }
   }
 }

--- a/csa-runner-api/src/test/resources/csaRequestMessage.json
+++ b/csa-runner-api/src/test/resources/csaRequestMessage.json
@@ -5,8 +5,7 @@
     "attributes": {
       "businessTimestamp": "2023-08-08T15:30:00Z",
       "gridModelUri": "https://cds/gridModelUri.signed.url",
-      "cracFileUri": "https://cds/cracFileUri.signed.url",
-      "resultsUri": "https://cds/resultsUri.signed.url"
+      "cracFileUri": "https://cds/cracFileUri.signed.url"
     }
   }
 }

--- a/csa-runner-app/pom.xml
+++ b/csa-runner-app/pom.xml
@@ -118,6 +118,15 @@
             <groupId>com.powsybl</groupId>
             <artifactId>open-rao-crac-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-glsk-document-io-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-glsk-document-cim</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <!-- TECHNICAL DEPENDENCIES -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/csa-runner-app/pom.xml
+++ b/csa-runner-app/pom.xml
@@ -37,6 +37,11 @@
                     <excludes>
                         <exclude>**/logback.xml</exclude>
                     </excludes>
+                    <archive>
+                        <manifestEntries>
+                            <Implementation-Version>${project.version}</Implementation-Version>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/csa-runner-app/src/main/java/com/farao_community/farao/swe_csa/app/FileExporter.java
+++ b/csa-runner-app/src/main/java/com/farao_community/farao/swe_csa/app/FileExporter.java
@@ -1,6 +1,6 @@
 package com.farao_community.farao.swe_csa.app;
 
-import com.farao_community.farao.gridcapa_swe_commons.exception.SweInternalException;
+import com.farao_community.farao.swe_csa.api.exception.CsaInternalException;
 import com.farao_community.farao.swe_csa.app.s3.S3ArtifactsAdapter;
 import com.powsybl.commons.datasource.MemDataSource;
 import com.powsybl.iidm.network.Network;
@@ -23,13 +23,13 @@ public class FileExporter {
         this.s3ArtifactsAdapter = s3ArtifactsAdapter;
     }
 
-    public String saveNetworkInArtifact(Network network, String networkFilePath) {
+    public String saveNetworkInArtifact(String taskId, Network network, String networkFilePath) {
         MemDataSource memDataSource = new MemDataSource();
         network.write(IIDM_EXPORT_FORMAT, new Properties(), memDataSource);
         try (InputStream is = memDataSource.newInputStream("", IIDM_EXTENSION)) {
             s3ArtifactsAdapter.uploadFile(networkFilePath, is);
         } catch (IOException e) {
-            throw new SweInternalException("Error while trying to save network to artifacts", e);
+            throw new CsaInternalException(taskId, "Error while trying to save network to artifacts", e);
         }
         return s3ArtifactsAdapter.generatePreSignedUrl(networkFilePath);
     }

--- a/csa-runner-app/src/main/java/com/farao_community/farao/swe_csa/app/FileImporter.java
+++ b/csa-runner-app/src/main/java/com/farao_community/farao/swe_csa/app/FileImporter.java
@@ -1,46 +1,79 @@
 package com.farao_community.farao.swe_csa.app;
 
-import com.farao_community.farao.rao_runner.api.exceptions.RaoRunnerException;
+import com.farao_community.farao.swe_csa.api.exception.CsaInvalidDataException;
 import com.farao_community.farao.swe_csa.app.s3.S3ArtifactsAdapter;
+import com.farao_community.farao.swe_csa.app.shift.SweCsaZonalData;
+import com.powsybl.glsk.api.GlskDocument;
+import com.powsybl.glsk.api.io.GlskDocumentImporter;
+import com.powsybl.glsk.api.io.GlskDocumentImporters;
+import com.powsybl.glsk.commons.ZonalData;
+import com.powsybl.iidm.modification.scalable.Scalable;
+import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.openrao.commons.OpenRaoException;
 import com.powsybl.openrao.data.crac.api.Crac;
 import com.powsybl.openrao.raoapi.json.JsonRaoParameters;
 import com.powsybl.openrao.raoapi.parameters.RaoParameters;
+import com.powsybl.sensitivity.SensitivityVariableSet;
 import org.apache.commons.io.FilenameUtils;
+import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
 
 import java.io.*;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 @Service
 public class FileImporter {
+    private final Logger businessLogger;
+
     private final S3ArtifactsAdapter s3ArtifactsAdapter;
 
     private static final DateTimeFormatter HOURLY_NAME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd'_'HHmm").withZone(ZoneId.of("UTC"));
 
-    public FileImporter(S3ArtifactsAdapter s3ArtifactsAdapter) {
+    public FileImporter(Logger businessLogger, S3ArtifactsAdapter s3ArtifactsAdapter) {
+        this.businessLogger = businessLogger;
         this.s3ArtifactsAdapter = s3ArtifactsAdapter;
     }
 
-    public Crac importCrac(String cracFileUrl, Network network) {
+    public Crac importCrac(String taskId, String cracFileUrl, Network network) {
         try {
-            return Crac.read(getFileNameFromUrl(cracFileUrl), openUrlStream(cracFileUrl), network);
-        } catch (OpenRaoException | RaoRunnerException | IOException e) {
-            String message = String.format("Exception occurred while importing CRAC file %s", getFileNameFromUrl(cracFileUrl));
-            throw new RaoRunnerException(message, e);
+            return Crac.read(getFileNameFromUrl(taskId, cracFileUrl), openUrlStream(taskId, cracFileUrl), network);
+        } catch (OpenRaoException | CsaInvalidDataException | IOException e) {
+            String message = String.format("Exception occurred while importing CRAC file %s", getFileNameFromUrl(taskId, cracFileUrl));
+            throw new CsaInvalidDataException(taskId, message, e);
         }
     }
 
-    public Network importNetwork(String networkFileUrl) {
+    public Network importNetwork(String taskId, String networkFileUrl) {
         try {
-            return Network.read(getFileNameFromUrl(networkFileUrl), openUrlStream(networkFileUrl));
+            return Network.read(getFileNameFromUrl(taskId, networkFileUrl), openUrlStream(taskId, networkFileUrl));
         } catch (Exception e) {
-            String message = String.format("Exception occurred while importing network %s", getFileNameFromUrl(networkFileUrl));
-            throw new RaoRunnerException(message, e);
+            String message = String.format("Exception occurred while importing network %s", getFileNameFromUrl(taskId, networkFileUrl));
+            throw new CsaInvalidDataException(taskId, message, e);
+        }
+    }
+
+    ZonalData<SensitivityVariableSet> importGlsk(String taskId, String instant, String glskUrl, Network network) throws CsaInvalidDataException {
+        try {
+            final InputStream glskFileInputStream = openUrlStream(taskId, glskUrl);
+            final GlskDocument ucteGlskProvider = GlskDocumentImporters.importGlsk(glskFileInputStream);
+            final OffsetDateTime offsetDateTime = OffsetDateTime.parse(instant);
+            return ucteGlskProvider.getZonalGlsks(network, offsetDateTime.toInstant());
+        } catch (Exception e) {
+            final String message = String.format("Error occurred during GLSK Provider creation for timestamp %s, using GLSK file %s, and CGM network file %s",
+                instant,
+                FilenameUtils.getName(glskUrl),
+                network.getNameOrId());
+            throw new CsaInvalidDataException(taskId, message, e);
         }
     }
 
@@ -54,21 +87,40 @@ public class FileImporter {
         return s3ArtifactsAdapter.generatePreSignedUrl(raoParametersFilePath);
     }
 
-    private InputStream openUrlStream(String urlString) {
+    private InputStream openUrlStream(String taskId, String urlString) {
         try {
-            URL url = new URL(urlString);
+            URL url = new URI(urlString).toURL();
             return url.openStream(); // NOSONAR
-        } catch (IOException e) {
-            throw new RaoRunnerException(String.format("Exception occurred while retrieving file content from : %s", urlString), e);
+        } catch (IOException | URISyntaxException | IllegalArgumentException e) {
+            throw new CsaInvalidDataException(taskId, String.format("Exception occurred while retrieving file content from : %s", urlString), e);
         }
     }
 
-    private String getFileNameFromUrl(String stringUrl) {
+    private String getFileNameFromUrl(String taskId, String stringUrl) {
         try {
-            URL url = new URL(stringUrl);
+            URL url = new URI(stringUrl).toURL();
             return FilenameUtils.getName(url.getPath());
-        } catch (IOException e) {
-            throw new RaoRunnerException(String.format("Exception occurred while retrieving file name from : %s", stringUrl), e);
+        } catch (IOException | URISyntaxException | IllegalArgumentException e) {
+            throw new CsaInvalidDataException(taskId, String.format("Exception occurred while retrieving file name from : %s", stringUrl), e);
+        }
+    }
+
+    public ZonalData<Scalable> getZonalData(String taskId, String glskUri, Network network, boolean filteredForSweCountries) {
+        try {
+            GlskDocumentImporter glskDocumentImporter = GlskDocumentImporters.findImporter(openUrlStream(taskId, glskUri));
+            GlskDocument glskDocument = glskDocumentImporter.importGlsk(openUrlStream(taskId, glskUri));
+            businessLogger.info("Glsk document imported");
+            // TODO MBR check if we need to do the same workaround here for angle monitoring by filtering for swe countries only
+            return glskDocument.getZonalScalable(network);
+        } catch (OpenRaoException e) {
+            businessLogger.error("Glsk document couldn't be imported, as a backup solution Scalable proportional to network generators will be used");
+            if (filteredForSweCountries) {
+                Set<Country> sweCountries = new HashSet<>(Arrays.asList(Country.FR, Country.PT, Country.ES));
+                return SweCsaZonalData.getZonalData(network, sweCountries);
+            } else {
+                return SweCsaZonalData.getZonalData(network);
+
+            }
         }
     }
 }

--- a/csa-runner-app/src/main/java/com/farao_community/farao/swe_csa/app/RequestService.java
+++ b/csa-runner-app/src/main/java/com/farao_community/farao/swe_csa/app/RequestService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.util.Optional;
 
 @Service
 public class RequestService {
@@ -46,6 +47,8 @@ public class RequestService {
             streamBridge.send(ACK_BRIDGE_NAME, jsonApiConverter.toJsonMessage(new CsaResponse(requestId, Status.ACCEPTED.toString(), ""), CsaResponse.class));
 
             businessLogger.info("Csa request received : {}", csaRequest);
+            // Implementation-Version from META-INF/MANIFEST.MF isn’t available in unit tests because tests run from the target/classes directory, not the actual packaged JAR
+            businessLogger.info("Current CSA runner version is: {}", Optional.ofNullable(this.getClass().getPackage().getImplementationVersion()).orElse("unknown"));
             Instant utcInstant = Instant.parse(csaRequest.getBusinessTimestamp());
             String raoResultDestinationPath = s3ArtifactsAdapter.createRaoResultDestination(OffsetDateTime.ofInstant(utcInstant, ZoneId.of("UTC")).toString());
             Pair<RaoResult, Status> result = dichotomyRunner.runDichotomy(csaRequest, raoResultDestinationPath);

--- a/csa-runner-app/src/main/java/com/farao_community/farao/swe_csa/app/dichotomy/DichotomyRunner.java
+++ b/csa-runner-app/src/main/java/com/farao_community/farao/swe_csa/app/dichotomy/DichotomyRunner.java
@@ -16,8 +16,9 @@ import com.farao_community.farao.swe_csa.app.*;
 import com.farao_community.farao.swe_csa.app.rao_result.RaoResultWithCounterTradeRangeActions;
 import com.farao_community.farao.swe_csa.app.s3.S3ArtifactsAdapter;
 import com.farao_community.farao.swe_csa.app.shift.ShiftDispatcher;
-import com.farao_community.farao.swe_csa.app.shift.SweCsaZonalData;
 import com.powsybl.glsk.commons.CountryEICode;
+import com.powsybl.glsk.commons.ZonalData;
+import com.powsybl.iidm.modification.scalable.Scalable;
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.openrao.data.crac.api.Crac;
@@ -77,8 +78,11 @@ public class DichotomyRunner {
     public Pair<RaoResult, Status> runDichotomy(CsaRequest csaRequest, String raoResultDestinationPath) throws GlskLimitationException, ShiftingException {
         RaoParameters raoParameters = RaoParameters.load();
         String raoParametersUrl = fileImporter.uploadRaoParameters(Instant.parse(csaRequest.getBusinessTimestamp()));
-        Network network = fileImporter.importNetwork(csaRequest.getGridModelUri());
-        Crac crac = fileImporter.importCrac(csaRequest.getCracFileUri(), network);
+        Network network = fileImporter.importNetwork(csaRequest.getId(), csaRequest.getGridModelUri());
+        // FIXME MBR temporary workaround to test integration before crac separated feature is finished
+        Crac crac = fileImporter.importCrac(csaRequest.getId(), csaRequest.getPtEsCracFileUri(), network);
+        ZonalData<Scalable> scalableZonalData = fileImporter.getZonalData(csaRequest.getId(), csaRequest.getGlskUri(), network, false);
+        ZonalData<Scalable> scalableZonalDataFilteredForSweCountries = fileImporter.getZonalData(csaRequest.getId(), csaRequest.getGlskUri(), network, true);
         updateCracWithCounterTrageRangeActions(crac);
 
         String initialVariant = network.getVariantManager().getWorkingVariantId();
@@ -109,7 +113,7 @@ public class DichotomyRunner {
         } catch (CsaInvalidDataException e) {
             businessLogger.warn(e.getMessage());
             businessLogger.warn("No counter trading will be done, only input network will be checked by rao");
-            RaoResult raoResult = sweCsaRaoValidator.validateNetwork(network, crac, raoParameters, csaRequest, raoParametersUrl, minCounterTradingValues).getRaoResult();
+            RaoResult raoResult = sweCsaRaoValidator.validateNetwork(network, crac, scalableZonalDataFilteredForSweCountries, raoParameters, csaRequest, raoParametersUrl, minCounterTradingValues).getRaoResult();
             fileExporter.saveRaoResultInArtifact(raoResultDestinationPath, raoResult, crac);
             return raoResult.isSecure() ? new Pair<>(raoResult, Status.FINISHED_SECURE) : new Pair<>(raoResult, Status.FINISHED_UNSECURE);
         }
@@ -117,7 +121,7 @@ public class DichotomyRunner {
         businessLogger.info("Starting Counter trading algorithm by validating input network without scaling");
         String noCtVariantName = "no-ct-PT-ES-0_FR-ES-0";
         setWorkingVariant(network, initialVariant, noCtVariantName);
-        DichotomyStepResult noCtStepResult = sweCsaRaoValidator.validateNetwork(network, crac, raoParameters, csaRequest, raoParametersUrl, minCounterTradingValues);
+        DichotomyStepResult noCtStepResult = sweCsaRaoValidator.validateNetwork(network, crac, scalableZonalDataFilteredForSweCountries, raoParameters, csaRequest, raoParametersUrl, minCounterTradingValues);
         resetToInitialVariant(network, initialVariant, noCtVariantName);
 
         logBorderOverload(noCtStepResult);
@@ -144,9 +148,9 @@ public class DichotomyRunner {
             String maxCtVariantName = getNewVariantName(maxCounterTradingValues);
             setWorkingVariant(network, initialVariant, maxCtVariantName);
 
-            SweCsaNetworkShifter networkShifter = new SweCsaNetworkShifter(SweCsaZonalData.getZonalData(network), initialExchanges.get(ES_FR), initialExchanges.get(ES_PT), new ShiftDispatcher(initialNetPositions));
+            SweCsaNetworkShifter networkShifter = new SweCsaNetworkShifter(scalableZonalData, initialExchanges.get(ES_FR), initialExchanges.get(ES_PT), new ShiftDispatcher(initialNetPositions));
             networkShifter.applyCounterTrading(maxCounterTradingValues, network);
-            DichotomyStepResult maxCtStepResult = sweCsaRaoValidator.validateNetwork(network, crac, raoParameters, csaRequest, raoParametersUrl, maxCounterTradingValues);
+            DichotomyStepResult maxCtStepResult = sweCsaRaoValidator.validateNetwork(network, crac, scalableZonalDataFilteredForSweCountries, raoParameters, csaRequest, raoParametersUrl, maxCounterTradingValues);
             resetToInitialVariant(network, initialVariant, maxCtVariantName);
 
             logBorderOverload(maxCtStepResult);
@@ -162,12 +166,12 @@ public class DichotomyRunner {
                 index.addFrEsDichotomyStepResult(0, noCtStepResult);
                 index.addFrEsDichotomyStepResult(ctFrEsUpperBound, maxCtStepResult);
                 index.setBestValidDichotomyStepResult(maxCtStepResult);
-                return processDichotomy(csaRequest, raoResultDestinationPath, raoParameters, raoParametersUrl, network, crac, initialVariant, networkShifter, index);
+                return processDichotomy(csaRequest, raoResultDestinationPath, raoParameters, raoParametersUrl, network, crac, scalableZonalData, initialVariant, networkShifter, index);
             }
         }
     }
 
-    private Pair<RaoResult, Status> processDichotomy(CsaRequest csaRequest, String raoResultDestinationPath, RaoParameters raoParameters, String raoParametersUrl, Network network, Crac crac, String initialVariant, SweCsaNetworkShifter networkShifter, Index index) {
+    private Pair<RaoResult, Status> processDichotomy(CsaRequest csaRequest, String raoResultDestinationPath, RaoParameters raoParameters, String raoParametersUrl, Network network, Crac crac, ZonalData<Scalable> scalableZonalDataFilteredForSweCountries, String initialVariant, SweCsaNetworkShifter networkShifter, Index index) {
         boolean interrupted = false;
         while (index.exitConditionIsNotMetForPtEs() || index.exitConditionIsNotMetForFrEs()) {
             if (interruptionService.getTasksToInterrupt().remove(csaRequest.getId())) {
@@ -182,7 +186,7 @@ public class DichotomyRunner {
                 businessLogger.info("Next CT values are '{}' for PT-ES and '{}' for FR-ES", counterTradingValues.getPtEsCt(), counterTradingValues.getFrEsCt());
                 setWorkingVariant(network, initialVariant, newVariantName);
                 networkShifter.applyCounterTrading(counterTradingValues, network);
-                ctStepResult = sweCsaRaoValidator.validateNetwork(network, crac, raoParameters, csaRequest, raoParametersUrl, counterTradingValues);
+                ctStepResult = sweCsaRaoValidator.validateNetwork(network, crac, scalableZonalDataFilteredForSweCountries, raoParameters, csaRequest, raoParametersUrl, counterTradingValues);
             } catch (GlskLimitationException e) {
                 businessLogger.warn("GLSK limits have been reached with CT of '{}' for PT-ES and '{}' for FR-ES", counterTradingValues.getPtEsCt(), counterTradingValues.getFrEsCt());
                 ctStepResult = DichotomyStepResult.fromFailure(ReasonInvalid.GLSK_LIMITATION, e.getMessage(), counterTradingValues);

--- a/csa-runner-app/src/main/java/com/farao_community/farao/swe_csa/app/dichotomy/DichotomyRunner.java
+++ b/csa-runner-app/src/main/java/com/farao_community/farao/swe_csa/app/dichotomy/DichotomyRunner.java
@@ -77,12 +77,13 @@ public class DichotomyRunner {
 
     public Pair<RaoResult, Status> runDichotomy(CsaRequest csaRequest, String raoResultDestinationPath) throws GlskLimitationException, ShiftingException {
         RaoParameters raoParameters = RaoParameters.load();
-        String raoParametersUrl = fileImporter.uploadRaoParameters(Instant.parse(csaRequest.getBusinessTimestamp()));
+        Instant instant = Instant.parse(csaRequest.getBusinessTimestamp());
+        String raoParametersUrl = fileImporter.uploadRaoParameters(instant);
         Network network = fileImporter.importNetwork(csaRequest.getId(), csaRequest.getGridModelUri());
         // FIXME MBR temporary workaround to test integration before crac separated feature is finished
         Crac crac = fileImporter.importCrac(csaRequest.getId(), csaRequest.getPtEsCracFileUri(), network);
-        ZonalData<Scalable> scalableZonalData = fileImporter.getZonalData(csaRequest.getId(), csaRequest.getGlskUri(), network, false);
-        ZonalData<Scalable> scalableZonalDataFilteredForSweCountries = fileImporter.getZonalData(csaRequest.getId(), csaRequest.getGlskUri(), network, true);
+        ZonalData<Scalable> scalableZonalData = fileImporter.getZonalData(csaRequest.getId(), instant, csaRequest.getGlskUri(), network, false);
+        ZonalData<Scalable> scalableZonalDataFilteredForSweCountries = fileImporter.getZonalData(csaRequest.getId(), instant, csaRequest.getGlskUri(), network, true);
         updateCracWithCounterTrageRangeActions(crac);
 
         String initialVariant = network.getVariantManager().getWorkingVariantId();

--- a/csa-runner-app/src/main/java/com/farao_community/farao/swe_csa/app/s3/S3ArtifactsAdapter.java
+++ b/csa-runner-app/src/main/java/com/farao_community/farao/swe_csa/app/s3/S3ArtifactsAdapter.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.io.InputStream;
+import java.time.OffsetDateTime;
 
 @Component
 public class S3ArtifactsAdapter {
@@ -33,6 +34,11 @@ public class S3ArtifactsAdapter {
 
     public String generatePreSignedUrl(String minioPath) {
         return S3AdapterUtil.generatePreSignedUrl(minioClient, basePath + "/" + minioPath, bucket);
+    }
+
+    public String createRaoResultDestination(String timestamp) {
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse(timestamp);
+        return "artifacts" + "/" + offsetDateTime.getYear() + "/" + offsetDateTime.getMonthValue() + "/" + offsetDateTime.getDayOfMonth() + "/" + offsetDateTime.getHour() + "_" + offsetDateTime.getMinute() + "/"  + "rao-result.json";
     }
 
 }

--- a/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/FileImporterTest.java
+++ b/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/FileImporterTest.java
@@ -1,7 +1,10 @@
 package com.farao_community.farao.swe_csa.app;
 
-import com.farao_community.farao.rao_runner.api.exceptions.RaoRunnerException;
+import com.farao_community.farao.swe_csa.api.exception.CsaInvalidDataException;
 import com.farao_community.farao.swe_csa.app.s3.S3ArtifactsAdapter;
+import com.powsybl.glsk.cim.CimGlskDocument;
+import com.powsybl.glsk.commons.ZonalData;
+import com.powsybl.iidm.modification.scalable.Scalable;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.openrao.data.crac.api.Crac;
 import org.assertj.core.api.Assertions;
@@ -11,7 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-import java.net.MalformedURLException;
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 
@@ -28,25 +31,25 @@ class FileImporterTest {
 
     @Test
     void checkIidmNetworkIsImportedCorrectly() {
-        Network network = fileImporter.importNetwork(Objects.requireNonNull(getClass().getResource("/rao_inputs/network.xiidm")).toString());
+        Network network = fileImporter.importNetwork("taskId", Objects.requireNonNull(getClass().getResource("/rao_inputs/network.xiidm")).toString());
         assertEquals("UCTE", network.getSourceFormat());
         assertEquals(4, network.getCountryCount());
     }
 
     @Test
     void importNetworkThrowsException() {
-        Assertions.assertThatThrownBy(() -> fileImporter.importNetwork("networkUrl"))
-            .isInstanceOf(RaoRunnerException.class)
-            .hasCauseInstanceOf(MalformedURLException.class)
+        Assertions.assertThatThrownBy(() -> fileImporter.importNetwork("taskId", "networkUrl"))
+            .isInstanceOf(CsaInvalidDataException.class)
+            .hasCauseInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("Exception occurred while retrieving file name from : networkUrl")
             .cause()
-            .hasMessageContaining("no protocol: networkUrl");
+            .hasMessageContaining("URI is not absolute");
     }
 
     @Test
     void checkJsonCracIsImportedCorrectly() {
-        Network network = fileImporter.importNetwork(Objects.requireNonNull(getClass().getResource("/rao_inputs/network.xiidm")).toString());
-        Crac crac = fileImporter.importCrac(Objects.requireNonNull(getClass().getResource("/rao_inputs/crac.json")).toString(), network);
+        Network network = fileImporter.importNetwork("taskId", Objects.requireNonNull(getClass().getResource("/rao_inputs/network.xiidm")).toString());
+        Crac crac = fileImporter.importCrac("taskId", Objects.requireNonNull(getClass().getResource("/rao_inputs/crac.json")).toString(), network);
         assertEquals("rao test crac", crac.getId());
         assertEquals(1, crac.getContingencies().size());
         assertEquals(11, crac.getFlowCnecs().size());
@@ -54,13 +57,26 @@ class FileImporterTest {
 
     @Test
     void importCracThrowsException() {
-        Network network = fileImporter.importNetwork(Objects.requireNonNull(getClass().getResource("/rao_inputs/network.xiidm")).toString());
-        Assertions.assertThatThrownBy(() -> fileImporter.importCrac("cracUrl", network))
-            .isInstanceOf(RaoRunnerException.class)
-            .hasCauseInstanceOf(MalformedURLException.class)
+        Network network = fileImporter.importNetwork("taskId", Objects.requireNonNull(getClass().getResource("/rao_inputs/network.xiidm")).toString());
+        Assertions.assertThatThrownBy(() -> fileImporter.importCrac("taskId", "cracUrl", network))
+            .isInstanceOf(CsaInvalidDataException.class)
+            .hasCauseInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("Exception occurred while retrieving file name from : cracUrl")
             .cause()
-            .hasMessageContaining("no protocol: cracUrl");
+            .hasMessageContaining("URI is not absolute");
+    }
+
+    @Test
+    void checkCimGlskIsImportedCorrectly() {
+        Network testNetwork = Network.read("testCase.xiidm", getClass().getResourceAsStream("/glsk/testCase.xiidm"));
+        CimGlskDocument cimGlskDocument = CimGlskDocument.importGlsk(getClass().getResourceAsStream("/glsk/glsk-document-cim.xml"));
+        assertEquals(1, cimGlskDocument.getZones().size());
+        Instant instant1 = Instant.parse("2017-04-13T07:00:00Z");
+        ZonalData<Scalable> zonalScalables = cimGlskDocument.getZonalScalable(testNetwork, instant1);
+        assertEquals(1, zonalScalables.getDataPerZone().size());
+        Scalable scalableFR = zonalScalables.getData("10YFR-RTE------C");
+        assertEquals(1, scalableFR.filterInjections(testNetwork).size());
+        assertEquals("FFR3AA1 _generator", scalableFR.filterInjections(testNetwork).getFirst().getId());
     }
 
     @Test

--- a/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/RequestServiceTest.java
+++ b/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/RequestServiceTest.java
@@ -49,7 +49,7 @@ class RequestServiceTest {
 
         when(s3ArtifactsAdapter.createRaoResultDestination(OffsetDateTime.ofInstant(Instant.parse("2023-08-08T15:30:00Z"), ZoneId.of("UTC")).toString())).thenReturn("resultsPath");
         when(s3ArtifactsAdapter.generatePreSignedUrl("resultsPath")).thenReturn("https://cds/resultsUri.signed.url");
-        when(dichotomyRunner.runDichotomy(new CsaRequest("id", "2023-08-08T15:30:00Z", "https://cds/gridModelUri.signed.url", "https://cds/cracFileUri.signed.url"), "resultsPath")).thenReturn(new Pair<>(null, Status.FINISHED_SECURE));
+        when(dichotomyRunner.runDichotomy(new CsaRequest("id", "2023-08-08T15:30:00Z", "https://cds/gridModelUri.signed.url", "https://cds/glskUri.signed.url", "https://cds/ptEsCracFileUri.signed.url", "https://cds/frEsCracFileUri.signed.url"), "resultsPath")).thenReturn(new Pair<>(null, Status.FINISHED_SECURE));
 
         byte[] resultBytes = requestService.launchCsaRequest(requestBytes);
         CsaResponse csaResponse = jsonApiConverter.fromJsonMessage(resultBytes, CsaResponse.class);

--- a/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/RequestServiceTest.java
+++ b/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/RequestServiceTest.java
@@ -3,6 +3,7 @@ package com.farao_community.farao.swe_csa.app;
 import com.farao_community.farao.dichotomy.api.exceptions.GlskLimitationException;
 import com.farao_community.farao.dichotomy.api.exceptions.ShiftingException;
 import com.farao_community.farao.swe_csa.api.JsonApiConverter;
+import com.farao_community.farao.swe_csa.api.resource.CsaRequest;
 import com.farao_community.farao.swe_csa.api.resource.CsaResponse;
 import com.farao_community.farao.swe_csa.api.resource.Status;
 import com.farao_community.farao.swe_csa.app.dichotomy.DichotomyRunner;
@@ -16,6 +17,10 @@ import org.springframework.cloud.stream.function.StreamBridge;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -41,10 +46,13 @@ class RequestServiceTest {
         byte[] requestBytes = getClass().getResourceAsStream("/csaRequestMessage.json").readAllBytes();
 
         when(streamBridge.send(any(), any())).thenReturn(true);
-        when(dichotomyRunner.runDichotomy(any())).thenReturn(new Pair<>(null, Status.FINISHED_SECURE));
-        when(s3ArtifactsAdapter.generatePreSignedUrl("https://cds/resultsUri.signed.url")).thenReturn("https://cds/resultsUri.signed.url");
 
-        CsaResponse csaResponse = jsonApiConverter.fromJsonMessage(requestService.launchCsaRequest(requestBytes), CsaResponse.class);
+        when(s3ArtifactsAdapter.createRaoResultDestination(OffsetDateTime.ofInstant(Instant.parse("2023-08-08T15:30:00Z"), ZoneId.of("UTC")).toString())).thenReturn("resultsPath");
+        when(s3ArtifactsAdapter.generatePreSignedUrl("resultsPath")).thenReturn("https://cds/resultsUri.signed.url");
+        when(dichotomyRunner.runDichotomy(new CsaRequest("id", "2023-08-08T15:30:00Z", "https://cds/gridModelUri.signed.url", "https://cds/cracFileUri.signed.url"), "resultsPath")).thenReturn(new Pair<>(null, Status.FINISHED_SECURE));
+
+        byte[] resultBytes = requestService.launchCsaRequest(requestBytes);
+        CsaResponse csaResponse = jsonApiConverter.fromJsonMessage(resultBytes, CsaResponse.class);
         CsaResponse expectedCsaResponse = new CsaResponse("id", Status.FINISHED_SECURE.toString(), "https://cds/resultsUri.signed.url");
         assertEquals(expectedCsaResponse.getId(), csaResponse.getId());
         assertEquals(expectedCsaResponse.getStatus(), csaResponse.getStatus());
@@ -56,7 +64,7 @@ class RequestServiceTest {
         byte[] requestBytes = getClass().getResourceAsStream("/csaRequestMessage.json").readAllBytes();
 
         when(streamBridge.send(any(), any())).thenReturn(true);
-        when(dichotomyRunner.runDichotomy(any())).thenThrow(new RuntimeException("Invalid data exception"));
+        when(dichotomyRunner.runDichotomy(any(), any())).thenThrow(new RuntimeException("Invalid data exception"));
         when(s3ArtifactsAdapter.generatePreSignedUrl("https://cds/resultsUri.signed.url")).thenReturn("https://cds/resultsUri.signed.url");
 
         assertEquals("{\"errors\":[{\"id\":\"id\",\"links\":null,\"status\":\"400\",\"code\":\"400-InvalidDataException\",\"title\":\"Exception happened\",\"detail\":\"Exception happened; nested exception is java.lang.RuntimeException: Invalid data exception\",\"source\":null,\"meta\":null}]}",

--- a/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/SweCsaZonalDataTest.java
+++ b/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/SweCsaZonalDataTest.java
@@ -23,7 +23,7 @@ class SweCsaZonalDataTest {
 
     @Test
     void zonalDataCreationTest() {
-        Network network = fileImporter.importNetwork(Objects.requireNonNull(getClass().getResource("/rao_inputs/network.xiidm")).toString());
+        Network network = fileImporter.importNetwork("taskId", Objects.requireNonNull(getClass().getResource("/rao_inputs/network.xiidm")).toString());
         ZonalData<Scalable> zonalData = SweCsaZonalData.getZonalData(network);
         assertNotNull(zonalData);
         assertEquals("[10YBE----------2, 10YCB-GERMANY--8, 10YFR-RTE------C, 10YNL----------L]", zonalData.getDataPerZone().keySet().stream().sorted().toList().toString());

--- a/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/dichotomy/SweCsaDichotomyRunnerTest.java
+++ b/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/dichotomy/SweCsaDichotomyRunnerTest.java
@@ -65,8 +65,8 @@ class SweCsaDichotomyRunnerTest {
         DichotomyRunner sweCsaDichotomyRunner = new DichotomyRunner(sweCsaRaoValidator, fileImporter, fileExporter, interruptionService, streamBridge, s3ArtifactsAdapter, LoggerFactory.getLogger(SweCsaDichotomyRunnerTest.class));
         sweCsaDichotomyRunner.setIndexPrecision(50);
         sweCsaDichotomyRunner.setMaxDichotomiesByBorder(10);
-        CsaRequest csaRequest = new CsaRequest("id", "2023-09-13T09:30:00Z", "cgm-url", "crac-url", "rao-result-url");
-        RaoResultWithCounterTradeRangeActions raoResult = (RaoResultWithCounterTradeRangeActions) sweCsaDichotomyRunner.runDichotomy(csaRequest).getFirst();
+        CsaRequest csaRequest = new CsaRequest("id", "2023-09-13T09:30:00Z", "cgm-url", "crac-url");
+        RaoResultWithCounterTradeRangeActions raoResult = (RaoResultWithCounterTradeRangeActions) sweCsaDichotomyRunner.runDichotomy(csaRequest, "rao-result-url").getFirst();
 
         Iterator<CounterTradeRangeActionResult> ctRaResultIt  = raoResult.getCounterTradingResult().getCounterTradeRangeActionResults().values().stream().sorted(Comparator.comparing(CounterTradeRangeActionResult::getCtRangeActionId)).collect(Collectors.toCollection(LinkedHashSet::new)).iterator();
 

--- a/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/dichotomy/SweCsaDichotomyRunnerTest.java
+++ b/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/dichotomy/SweCsaDichotomyRunnerTest.java
@@ -61,8 +61,8 @@ class SweCsaDichotomyRunnerTest {
         Mockito.when(fileImporter.uploadRaoParameters(utcInstant)).thenReturn("rao-parameters-url");
         Mockito.when(fileImporter.importNetwork("id", "cgm-url")).thenReturn(network);
         Mockito.when(fileImporter.importCrac("id", "ptEs-crac-url", network)).thenReturn(crac);
-        Mockito.when(fileImporter.getZonalData("id", "glsk-url", network, false)).thenReturn(scalableZonalData);
-        Mockito.when(fileImporter.getZonalData("id", "glsk-url", network, true)).thenReturn(scalableZonalData);
+        Mockito.when(fileImporter.getZonalData("id", utcInstant, "glsk-url", network, false)).thenReturn(scalableZonalData);
+        Mockito.when(fileImporter.getZonalData("id", utcInstant, "glsk-url", network, true)).thenReturn(scalableZonalData);
         Mockito.when(fileExporter.saveNetworkInArtifact(Mockito.anyString(), Mockito.any(), Mockito.any())).thenReturn("scaled-network-url");
         AbstractRaoResponse raoResponse = Mockito.mock(AbstractRaoResponse.class);
         Mockito.when(raoRunnerClient.runRao(Mockito.any())).thenReturn(raoResponse);

--- a/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/dichotomy/SweCsaRaoValidatorMock.java
+++ b/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/dichotomy/SweCsaRaoValidatorMock.java
@@ -4,6 +4,8 @@ import com.farao_community.farao.rao_runner.api.resource.RaoSuccessResponse;
 import com.farao_community.farao.rao_runner.starter.RaoRunnerClient;
 import com.farao_community.farao.swe_csa.api.resource.CsaRequest;
 import com.farao_community.farao.swe_csa.app.FileExporter;
+import com.powsybl.glsk.commons.ZonalData;
+import com.powsybl.iidm.modification.scalable.Scalable;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.openrao.data.crac.api.Crac;
 import com.powsybl.openrao.data.raoresult.api.RaoResult;
@@ -24,7 +26,7 @@ public class SweCsaRaoValidatorMock extends SweCsaRaoValidator {
     }
 
     @Override
-    public DichotomyStepResult validateNetwork(Network network, Crac crac, RaoParameters raoParameters, CsaRequest csaRequest, String raoParametersUrl, CounterTradingValues counterTradingValues) {
+    public DichotomyStepResult validateNetwork(Network network, Crac crac, ZonalData<Scalable> scalableZonalData, RaoParameters raoParameters, CsaRequest csaRequest, String raoParametersUrl, CounterTradingValues counterTradingValues) {
         RaoSuccessResponse raoResponse = Mockito.mock(RaoSuccessResponse.class);
         RaoResult raoResult = Mockito.mock(RaoResult.class);
         Pair<String, Double> ptEsMostLimitingCnec = Pair.of("ptEsCnec", counterTradingValues.getPtEsCt() >= 0 ? 100.0 : -100.0);

--- a/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/dichotomy/SweCsaRaoValidatorTest.java
+++ b/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/dichotomy/SweCsaRaoValidatorTest.java
@@ -101,6 +101,6 @@ class SweCsaRaoValidatorTest {
         SweCsaRaoValidator sweCsaRaoValidator = new SweCsaRaoValidator(fileExporter, raoRunnerClient, LoggerFactory.getLogger(S3AdapterUtil.class));
         Mockito.when(raoRunnerClient.runRao(any())).thenReturn(new RaoFailureResponse.Builder().withId("id").withErrorMessage("errorMessage").build());
         assertThrows(CsaInternalException.class, () -> sweCsaRaoValidator.validateNetwork(network, crac, new RaoParameters(),
-            new CsaRequest("id", "2024-12-01T15:30:00Z", "", "", ""), "raoParametersUrl", new CounterTradingValues(0.0, 0.0)));
+            new CsaRequest("id", "2024-12-01T15:30:00Z", "", ""), "raoParametersUrl", new CounterTradingValues(0.0, 0.0)));
     }
 }

--- a/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/dichotomy/SweCsaRaoValidatorTest.java
+++ b/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/dichotomy/SweCsaRaoValidatorTest.java
@@ -46,7 +46,7 @@ class SweCsaRaoValidatorTest {
     @Test
     void testGetBorderFlowCnecs() {
         Network network = Network.read(getClass().getResource("/rao_inputs/network.xiidm").getPath());
-        Crac crac = fileImporter.importCrac(Objects.requireNonNull(getClass().getResource("/rao_inputs/crac.json")).toString(), network);
+        Crac crac = fileImporter.importCrac("taskId", Objects.requireNonNull(getClass().getResource("/rao_inputs/crac.json")).toString(), network);
 
         Set<FlowCnec> cnecsFr = SweCsaRaoValidator.getBorderFlowCnecs(crac, network, Country.FR);
         Set<FlowCnec> cnecsDe = SweCsaRaoValidator.getBorderFlowCnecs(crac, network, Country.DE);
@@ -96,11 +96,11 @@ class SweCsaRaoValidatorTest {
     @Test
     void testValidateNetworkRaoFailureResponse() {
         Network network = Network.read(getClass().getResource("/rao_inputs/network.xiidm").getPath());
-        Crac crac = fileImporter.importCrac(Objects.requireNonNull(getClass().getResource("/rao_inputs/crac.json")).toString(), network);
+        Crac crac = fileImporter.importCrac("taskId", Objects.requireNonNull(getClass().getResource("/rao_inputs/crac.json")).toString(), network);
 
         SweCsaRaoValidator sweCsaRaoValidator = new SweCsaRaoValidator(fileExporter, raoRunnerClient, LoggerFactory.getLogger(S3AdapterUtil.class));
         Mockito.when(raoRunnerClient.runRao(any())).thenReturn(new RaoFailureResponse.Builder().withId("id").withErrorMessage("errorMessage").build());
-        assertThrows(CsaInternalException.class, () -> sweCsaRaoValidator.validateNetwork(network, crac, new RaoParameters(),
-            new CsaRequest("id", "2024-12-01T15:30:00Z", "", ""), "raoParametersUrl", new CounterTradingValues(0.0, 0.0)));
+        assertThrows(CsaInternalException.class, () -> sweCsaRaoValidator.validateNetwork(network, crac, null, new RaoParameters(),
+            new CsaRequest("id", "2024-12-01T15:30:00Z", "", "", "", ""), "raoParametersUrl", new CounterTradingValues(0.0, 0.0)));
     }
 }

--- a/csa-runner-app/src/test/resources/csaRequestMessage.json
+++ b/csa-runner-app/src/test/resources/csaRequestMessage.json
@@ -5,7 +5,9 @@
     "attributes": {
       "businessTimestamp": "2023-08-08T15:30:00Z",
       "gridModelUri": "https://cds/gridModelUri.signed.url",
-      "cracFileUri": "https://cds/cracFileUri.signed.url"
+      "glskUri": "https://cds/glskUri.signed.url",
+      "ptEsCracFileUri": "https://cds/ptEsCracFileUri.signed.url",
+      "frEsCracFileUri": "https://cds/frEsCracFileUri.signed.url"
     }
   }
 }

--- a/csa-runner-app/src/test/resources/csaRequestMessage.json
+++ b/csa-runner-app/src/test/resources/csaRequestMessage.json
@@ -5,8 +5,7 @@
     "attributes": {
       "businessTimestamp": "2023-08-08T15:30:00Z",
       "gridModelUri": "https://cds/gridModelUri.signed.url",
-      "cracFileUri": "https://cds/cracFileUri.signed.url",
-      "resultsUri": "https://cds/resultsUri.signed.url"
+      "cracFileUri": "https://cds/cracFileUri.signed.url"
     }
   }
 }

--- a/csa-runner-app/src/test/resources/glsk/glsk-document-cim.xml
+++ b/csa-runner-app/src/test/resources/glsk/glsk-document-cim.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GLSK_MarketDocument xsi:schemaLocation="urn:iec62325.351:tc57wg16:451-n:glskdocument:2:1 iec62325-451-n-glsk_v2_1.xsd" xmlns="urn:iec62325.351:tc57wg16:451-n:glskdocument:2:1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <mRID>10XES-REE------E-20170412-SWECCD2</mRID>
+    <revisionNumber>1</revisionNumber>
+    <type>B22</type>
+    <process.processType>A48</process.processType>
+    <sender_MarketParticipant.mRID codingScheme="A01">10XES-REE------E</sender_MarketParticipant.mRID>
+    <sender_MarketParticipant.marketRole.type>A04</sender_MarketParticipant.marketRole.type>
+    <receiver_MarketParticipant.mRID codingScheme="A01">22XCORESO------S</receiver_MarketParticipant.mRID>
+    <receiver_MarketParticipant.marketRole.type>A36</receiver_MarketParticipant.marketRole.type>
+    <createdDateTime>2017-07-18T06:31:36Z</createdDateTime>
+    <time_Period.timeInterval>
+        <start>2017-04-12T22:00Z</start>
+        <end>2017-04-13T22:00Z</end>
+    </time_Period.timeInterval>
+    <domain.mRID codingScheme="A01">10YCB-FR-ES-PT-S</domain.mRID>
+    <TimeSeries>
+        <mRID>B45TestFR</mRID>
+        <subject_Domain.mRID codingScheme="A01">10YFR-RTE------C</subject_Domain.mRID>
+        <curveType>A03</curveType>
+        <Period>
+            <timeInterval>
+                <start>2017-04-12T22:00Z</start>
+                <end>2017-04-13T22:00Z</end>
+            </timeInterval>
+            <resolution>PT60M</resolution>
+            <Point>
+                <position>1</position>
+                <SKBlock_TimeSeries>
+                    <businessType>B45</businessType>
+                    <mktPSRType.psrType>A01</mktPSRType.psrType>
+                    <flowDirection.direction>A01</flowDirection.direction>
+                    <measurement_Unit.name>MAW</measurement_Unit.name>
+                    <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+                    <RegisteredResource>
+                        <mRID codingScheme="A02">FFR1AA1 _generator</mRID>
+                        <name>FFR1AA1 _generator</name>
+                        <resourceCapacity.maximumCapacity>2001</resourceCapacity.maximumCapacity>
+                        <resourceCapacity.minimumCapacity>-401</resourceCapacity.minimumCapacity>
+                    </RegisteredResource>
+                </SKBlock_TimeSeries>
+                <SKBlock_TimeSeries>
+                    <businessType>B45</businessType>
+                    <mktPSRType.psrType>A01</mktPSRType.psrType>
+                    <flowDirection.direction>A01</flowDirection.direction>
+                    <measurement_Unit.name>MAW</measurement_Unit.name>
+                    <attributeInstanceComponent.position>2</attributeInstanceComponent.position>
+                    <RegisteredResource>
+                        <mRID codingScheme="A02">FFR2AA1 _generator</mRID>
+                        <name>FFR2AA1 _generator</name>
+                        <resourceCapacity.maximumCapacity>2002</resourceCapacity.maximumCapacity>
+                        <resourceCapacity.minimumCapacity>-402</resourceCapacity.minimumCapacity>
+                    </RegisteredResource>
+                </SKBlock_TimeSeries>
+                <SKBlock_TimeSeries>
+                    <businessType>B45</businessType>
+                    <mktPSRType.psrType>A01</mktPSRType.psrType>
+                    <flowDirection.direction>A01</flowDirection.direction>
+                    <measurement_Unit.name>MAW</measurement_Unit.name>
+                    <attributeInstanceComponent.position>3</attributeInstanceComponent.position>
+                    <RegisteredResource>
+                        <mRID codingScheme="A02">FFR3AA1 _generator</mRID>
+                        <name>FFR3AA1 _generator</name>
+                        <resourceCapacity.maximumCapacity>3003</resourceCapacity.maximumCapacity>
+                        <resourceCapacity.minimumCapacity>-403.0</resourceCapacity.minimumCapacity>
+                    </RegisteredResource>
+                </SKBlock_TimeSeries>
+                <SKBlock_TimeSeries>
+                    <businessType>B45</businessType>
+                    <mktPSRType.psrType>A01</mktPSRType.psrType>
+                    <flowDirection.direction>A02</flowDirection.direction>
+                    <measurement_Unit.name>MAW</measurement_Unit.name>
+                    <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+                    <RegisteredResource>
+                        <mRID codingScheme="A02">FFR1AA1 _generator</mRID>
+                        <name>FFR1AA1 _generator</name>
+                        <resourceCapacity.maximumCapacity>2001</resourceCapacity.maximumCapacity>
+                        <resourceCapacity.minimumCapacity>-401</resourceCapacity.minimumCapacity>
+                    </RegisteredResource>
+                </SKBlock_TimeSeries>
+            </Point>
+            <Point>
+                <position>10</position>
+                <SKBlock_TimeSeries>
+                    <businessType>B45</businessType>
+                    <mktPSRType.psrType>A01</mktPSRType.psrType>
+                    <flowDirection.direction>A01</flowDirection.direction>
+                    <measurement_Unit.name>MAW</measurement_Unit.name>
+                    <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+                    <RegisteredResource>
+                        <mRID codingScheme="A02">FFR3AA1 _generator</mRID>
+                        <name>FFR3AA1 _generator</name>
+                        <resourceCapacity.maximumCapacity>3003</resourceCapacity.maximumCapacity>
+                        <resourceCapacity.minimumCapacity>-401</resourceCapacity.minimumCapacity>
+                    </RegisteredResource>
+                </SKBlock_TimeSeries>
+            </Point>
+        </Period>
+    </TimeSeries>
+</GLSK_MarketDocument>

--- a/csa-runner-app/src/test/resources/glsk/testCase.xiidm
+++ b/csa-runner-app/src/test/resources/glsk/testCase.xiidm
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" id="20140116_0830_2D4_UX1_pst" caseDate="2014-01-16T08:30:00.000+01:00" forecastDistance="0" sourceFormat="UCTE">
+    <iidm:substation id="BBE1AA" country="BE">
+        <iidm:voltageLevel id="BBE1AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BBE1AA1 " v="380.0" angle="-2.353799343109131"/>
+                <iidm:bus id="BBE3AA1 " v="380.0" angle="0.0"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="BBE1AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1500.0" targetV="400.0" targetQ="-0.0" bus="BBE1AA1 " connectableBus="BBE1AA1 " p="-1500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="BBE3AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2500.0" targetV="400.0" targetQ="-0.0" bus="BBE3AA1 " connectableBus="BBE3AA1 " p="-2500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="BBE1AA1 _load" loadType="UNDEFINED" p0="3000.0" q0="0.0" bus="BBE1AA1 " connectableBus="BBE1AA1 " p="3000.0"/>
+            <iidm:load id="BBE3AA1 _load" loadType="UNDEFINED" p0="1500.0" q0="0.0" bus="BBE3AA1 " connectableBus="BBE3AA1 " p="1500.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="BBE1AA1  BBE3AA1  2" r="0.20800000429153442" x="25.5" g="1.0625000186337274E-6" b="-2.1624998680636054E-6" ratedU1="400.0" ratedU2="400.0" bus1="BBE3AA1 " connectableBus1="BBE3AA1 " voltageLevelId1="BBE1AA1" bus2="BBE1AA1 " connectableBus2="BBE1AA1 " voltageLevelId2="BBE1AA1" p1="-227.49346923828125" p2="227.49346923828125">
+            <iidm:phaseTapChanger lowTapPosition="-33" tapPosition="5" regulationMode="FIXED_TAP">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="30.036436080932617"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="29.165605545043945"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="28.29132080078125"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="27.413660049438477"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="26.53270721435547"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="25.648548126220703"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="24.761274337768555"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="23.870973587036133"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="22.977739334106445"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="22.0816650390625"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="21.182849884033203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="20.281387329101562"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="19.377382278442383"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="18.470935821533203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="17.56215476989746"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="16.651138305664062"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="15.737995147705078"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="14.82283878326416"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="13.905777931213379"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="12.986922264099121"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="12.066386222839355"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="11.144285202026367"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="10.220732688903809"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="9.295848846435547"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="8.369750022888184"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="7.442552089691162"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="6.514379024505615"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.585349082946777"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="4.655583381652832"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.7252047061920166"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.7943341732025146"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.8630945682525635"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.9316088557243347"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.9316088557243347"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.8630945682525635"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.7943341732025146"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-3.7252047061920166"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-4.655583381652832"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.585349082946777"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-6.514379024505615"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-7.442552089691162"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-8.369750022888184"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-9.295848846435547"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-10.220732688903809"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-11.144285202026367"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-12.066386222839355"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-12.986922264099121"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-13.905777931213379"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-14.82283878326416"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-15.737995147705078"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-16.651138305664062"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-17.56215476989746"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-18.470935821533203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-19.377382278442383"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-20.281387329101562"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-21.182849884033203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-22.0816650390625"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-22.977739334106445"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-23.870973587036133"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-24.761274337768555"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-25.648548126220703"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-26.53270721435547"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-27.413660049438477"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-28.29132080078125"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-29.165605545043945"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-30.036436080932617"/>
+            </iidm:phaseTapChanger>
+            <iidm:currentLimits2 permanentLimit="1227.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="BBE2AA" country="BE">
+        <iidm:voltageLevel id="BBE2AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BBE2AA1 " v="380.0" angle="2.1468396186828613"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="BBE2AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="3000.0" targetV="400.0" targetQ="-0.0" bus="BBE2AA1 " connectableBus="BBE2AA1 " p="-3000.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="BBE2AA1 _load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="BBE2AA1 " connectableBus="BBE2AA1 " p="1000.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="DDE1AA" country="DE">
+        <iidm:voltageLevel id="DDE1AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="DDE1AA1 " v="380.0" angle="-13.329349517822266"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="DDE1AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2500.0" targetV="400.0" targetQ="-0.0" bus="DDE1AA1 " connectableBus="DDE1AA1 " p="-2500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="DDE1AA1 _load" loadType="UNDEFINED" p0="3500.0" q0="0.0" bus="DDE1AA1 " connectableBus="DDE1AA1 " p="3500.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="DDE2AA" country="DE">
+        <iidm:voltageLevel id="DDE2AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="DDE2AA1 " v="380.0" angle="-11.774831771850586"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="DDE2AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2000.0" targetV="400.0" targetQ="-0.0" bus="DDE2AA1 " connectableBus="DDE2AA1 " p="-2000.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="DDE2AA1 _load" loadType="UNDEFINED" p0="3000.0" q0="0.0" bus="DDE2AA1 " connectableBus="DDE2AA1 " p="3000.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="DDE3AA" country="DE">
+        <iidm:voltageLevel id="DDE3AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="DDE3AA1 " v="380.0" angle="-10.916015625"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="DDE3AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1500.0" targetV="400.0" targetQ="-0.0" bus="DDE3AA1 " connectableBus="DDE3AA1 " p="-1500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="DDE3AA1 _load" loadType="UNDEFINED" p0="2000.0" q0="0.0" bus="DDE3AA1 " connectableBus="DDE3AA1 " p="2000.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FFR1AA" country="FR">
+        <iidm:voltageLevel id="FFR1AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FFR1AA1 " v="380.0" angle="0.13716478645801544"/>
+                <iidm:bus id="FFR2AA1 " v="380.0" angle="-5.659938335418701"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FFR1AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2000.0" targetV="400.0" targetQ="-0.0" bus="FFR1AA1 " connectableBus="FFR1AA1 " p="-2000.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="FFR2AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2000.0" targetV="400.0" targetQ="-0.0" bus="FFR2AA1 " connectableBus="FFR2AA1 " p="-2000.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FFR1AA1 _load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="FFR1AA1 " connectableBus="FFR1AA1 " p="1000.0"/>
+            <iidm:load id="FFR2AA1 _load" loadType="UNDEFINED" p0="3500.0" q0="0.0" bus="FFR2AA1 " connectableBus="FFR2AA1 " p="3500.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="FFR1AA1  FFR2AA1  2" r="0.08669999986886978" x="13.98799991607666" g="1.2216000868647825E-6" b="-2.3275001694855746E-6" ratedU1="400.0" ratedU2="400.0" bus1="FFR2AA1 " connectableBus1="FFR2AA1 " voltageLevelId1="FFR1AA1" bus2="FFR1AA1 " connectableBus2="FFR1AA1 " voltageLevelId2="FFR1AA1" p1="279.1942443847656" p2="-279.1942443847656">
+            <iidm:phaseTapChanger lowTapPosition="-17" tapPosition="-5" regulationMode="FIXED_TAP">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="24.626773834228516"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="23.21863555908203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="21.803354263305664"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="20.38130760192871"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="18.95288848876953"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="17.51850128173828"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="16.07855987548828"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="14.633487701416016"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="13.183723449707031"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="11.729705810546875"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="10.27188777923584"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="8.81072998046875"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="7.346695423126221"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.880255699157715"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="4.411885738372803"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.9420645236968994"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.471274733543396"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.471274733543396"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.9420645236968994"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-4.411885738372803"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.880255699157715"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-7.346695423126221"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-8.81072998046875"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-10.27188777923584"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-11.729705810546875"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-13.183723449707031"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-14.633487701416016"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-16.07855987548828"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-17.51850128173828"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-18.95288848876953"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-20.38130760192871"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-21.803354263305664"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-23.21863555908203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-24.626773834228516"/>
+            </iidm:phaseTapChanger>
+            <iidm:currentLimits2 permanentLimit="2329.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="FFR3AA" country="FR">
+        <iidm:voltageLevel id="FFR3AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FFR3AA1 " v="380.0" angle="0.8586146235466003"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FFR3AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="3000.0" targetV="400.0" targetQ="-0.0" bus="FFR3AA1 " connectableBus="FFR3AA1 " p="-3000.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FFR3AA1 _load" loadType="UNDEFINED" p0="1500.0" q0="0.0" bus="FFR3AA1 " connectableBus="FFR3AA1 " p="1500.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="NNL1AA" country="NL">
+        <iidm:voltageLevel id="NNL1AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NNL1AA1 " v="380.0" angle="-4.895452976226807"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="NNL1AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1500.0" targetV="400.0" targetQ="-0.0" bus="NNL1AA1 " connectableBus="NNL1AA1 " p="-1500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="NNL1AA1 _load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="NNL1AA1 " connectableBus="NNL1AA1 " p="1000.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="NNL2AA" country="NL">
+        <iidm:voltageLevel id="NNL2AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NNL2AA1 " v="380.0" angle="-4.663552761077881"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="NNL2AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="500.0" targetV="400.0" targetQ="-0.0" bus="NNL2AA1 " connectableBus="NNL2AA1 " p="-500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="NNL2AA1 _load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="NNL2AA1 " connectableBus="NNL2AA1 " p="1000.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="NNL3AA" country="NL">
+        <iidm:voltageLevel id="NNL3AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NNL3AA1 " v="380.0" angle="-7.111279010772705"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="NNL3AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2500.0" targetV="400.0" targetQ="-0.0" bus="NNL3AA1 " connectableBus="NNL3AA1 " p="-2500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="NNL3AA1 _load" loadType="UNDEFINED" p0="2500.0" q0="0.0" bus="NNL3AA1 " connectableBus="NNL3AA1 " p="2500.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="BBE1AA1  BBE2AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE1AA1 " connectableBus1="BBE1AA1 " voltageLevelId1="BBE1AA1" bus2="BBE2AA1 " connectableBus2="BBE2AA1 " voltageLevelId2="BBE2AA1" p1="-1134.2760009765625" p2="1134.2760009765625">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="BBE1AA1  BBE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE1AA1 " connectableBus1="BBE1AA1 " voltageLevelId1="BBE1AA1" bus2="BBE3AA1 " connectableBus2="BBE3AA1 " voltageLevelId2="BBE1AA1" p1="-593.217529296875" p2="593.217529296875">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="BBE2AA1  BBE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE2AA1 " connectableBus1="BBE2AA1 " voltageLevelId1="BBE2AA1" bus2="BBE3AA1 " connectableBus2="BBE3AA1 " voltageLevelId2="BBE1AA1" p1="541.0584106445312" p2="-541.0584106445312">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR1AA1  FFR2AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR1AA1 " connectableBus1="FFR1AA1 " voltageLevelId1="FFR1AA1" bus2="FFR2AA1 " connectableBus2="FFR2AA1 " voltageLevelId2="FFR1AA1" p1="1461.01806640625" p2="-1461.01806640625">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR1AA1  FFR3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR1AA1 " connectableBus1="FFR1AA1 " voltageLevelId1="FFR1AA1" bus2="FFR3AA1 " connectableBus2="FFR3AA1 " voltageLevelId2="FFR3AA1" p1="-181.82379150390625" p2="181.82379150390625">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR2AA1  FFR3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR2AA1 " connectableBus1="FFR2AA1 " voltageLevelId1="FFR1AA1" bus2="FFR3AA1 " connectableBus2="FFR3AA1 " voltageLevelId2="FFR3AA1" p1="-1642.841796875" p2="1642.841796875">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE1AA1  DDE2AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE1AA1 " connectableBus1="DDE1AA1 " voltageLevelId1="DDE1AA1" bus2="DDE2AA1 " connectableBus2="DDE2AA1 " voltageLevelId2="DDE2AA1" p1="-391.77813720703125" p2="391.77813720703125">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE1AA1  DDE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE1AA1 " connectableBus1="DDE1AA1 " voltageLevelId1="DDE1AA1" bus2="DDE3AA1 " connectableBus2="DDE3AA1 " voltageLevelId2="DDE3AA1" p1="-608.2218627929688" p2="608.2218627929688">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE2AA1  DDE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE2AA1 " connectableBus1="DDE2AA1 " voltageLevelId1="DDE2AA1" bus2="DDE3AA1 " connectableBus2="DDE3AA1 " voltageLevelId2="DDE3AA1" p1="-216.44374084472656" p2="216.44374084472656">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL1AA1  NNL2AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL1AA1 " connectableBus1="NNL1AA1 " voltageLevelId1="NNL1AA1" bus2="NNL2AA1 " connectableBus2="NNL2AA1 " voltageLevelId2="NNL2AA1" p1="-58.444793701171875" p2="58.444793701171875">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL1AA1  NNL3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL1AA1 " connectableBus1="NNL1AA1 " voltageLevelId1="NNL1AA1" bus2="NNL3AA1 " connectableBus2="NNL3AA1 " voltageLevelId2="NNL3AA1" p1="558.44482421875" p2="-558.44482421875">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL2AA1  NNL3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL2AA1 " connectableBus1="NNL2AA1 " voltageLevelId1="NNL2AA1" bus2="NNL3AA1 " connectableBus2="NNL3AA1 " voltageLevelId2="NNL3AA1" p1="616.8895874023438" p2="-616.8895874023438">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR2AA1  DDE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR2AA1 " connectableBus1="FFR2AA1 " voltageLevelId1="FFR1AA1" bus2="DDE3AA1 " connectableBus2="DDE3AA1 " voltageLevelId2="DDE3AA1" p1="1324.6656494140625" p2="-1324.6656494140625">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE2AA1  NNL3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE2AA1 " connectableBus1="DDE2AA1 " voltageLevelId1="DDE2AA1" bus2="NNL3AA1 " connectableBus2="NNL3AA1 " voltageLevelId2="NNL3AA1" p1="-1175.3343505859375" p2="1175.3343505859375">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL2AA1  BBE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL2AA1 " connectableBus1="NNL2AA1 " voltageLevelId1="NNL2AA1" bus2="BBE3AA1 " connectableBus2="BBE3AA1 " voltageLevelId2="BBE1AA1" p1="-1175.3343505859375" p2="1175.3343505859375">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="BBE2AA1  FFR3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE2AA1 " connectableBus1="BBE2AA1 " voltageLevelId1="BBE2AA1" bus2="FFR3AA1 " connectableBus2="FFR3AA1 " voltageLevelId2="FFR3AA1" p1="324.6656188964844" p2="-324.6656188964844">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+</iidm:network>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)

- **New Features**
	- New signature for csa-request API to integrate with Artelys wrapper and greffin module:
	          - Accepting two crac files one for PT-ES border and one for FR-ES border. 
	          - Remove rao-result url from csa request
	           - Add GLSK file as input
	
	- Add GlskDocumentImporter in the CSA runner so that the GLSK data can be imported from a document.
	- Logging the current version of csa-runner for easier debug and monitoring.
	- Enhanced file handling with dynamic, timestamp-based destination paths for output artifacts.
