### PR TITLE
Use lf parameters from rao parameters during shifting

### DIFF
--- a/csa-runner-app/src/main/java/com/farao_community/farao/swe_csa/app/dichotomy/DichotomyRunner.java
+++ b/csa-runner-app/src/main/java/com/farao_community/farao/swe_csa/app/dichotomy/DichotomyRunner.java
@@ -145,7 +145,7 @@ public class DichotomyRunner {
             setWorkingVariant(network, initialVariant, maxCtVariantName);
 
             SweCsaNetworkShifter networkShifter = new SweCsaNetworkShifter(scalableZonalData, initialExchanges.get(ES_FR), initialExchanges.get(ES_PT), new ShiftDispatcher(initialNetPositions));
-            networkShifter.applyCounterTrading(maxCounterTradingValues, network);
+            networkShifter.applyCounterTrading(maxCounterTradingValues, network, raoParameters);
 
             ParallelDichotomiesResult maxCtParallelDichotomiesResult = supplyParallelDichotomiesResult(csaRequest, raoParameters, raoParametersUrl, network, cracPtEs, cracFrEs, scalableZonalData, maxCounterTradingValues);
 
@@ -188,7 +188,7 @@ public class DichotomyRunner {
             try {
                 businessLogger.info("Next CT values are '{}' for PT-ES and '{}' for FR-ES", counterTradingValues.ptEsCt(), counterTradingValues.frEsCt());
                 setWorkingVariant(network, initialVariant, newVariantName);
-                networkShifter.applyCounterTrading(counterTradingValues, network);
+                networkShifter.applyCounterTrading(counterTradingValues, network, raoParameters);
 
                 ParallelDichotomiesResult parallelDichotomiesResult = supplyParallelDichotomiesResult(csaRequest, raoParameters, raoParametersUrl, network, cracPtEs, cracFrEs, scalableZonalDataFilteredForSweCountries, counterTradingValues);
 

--- a/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/dichotomy/SweCsaNetworkShifterTest.java
+++ b/csa-runner-app/src/test/java/com/farao_community/farao/swe_csa/app/dichotomy/SweCsaNetworkShifterTest.java
@@ -1,8 +1,5 @@
 package com.farao_community.farao.swe_csa.app.dichotomy;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.*;
-
 import com.farao_community.farao.dichotomy.api.exceptions.GlskLimitationException;
 import com.farao_community.farao.dichotomy.api.exceptions.ShiftingException;
 import com.farao_community.farao.gridcapa_swe_commons.shift.CountryBalanceComputation;
@@ -12,18 +9,25 @@ import com.powsybl.glsk.commons.ZonalData;
 import com.powsybl.iidm.modification.scalable.Scalable;
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openrao.commons.EICode;
 import com.powsybl.openrao.raoapi.parameters.RaoParameters;
 import com.powsybl.openrao.raoapi.parameters.extensions.LoadFlowAndSensitivityParameters;
+import com.powsybl.openrao.raoapi.parameters.extensions.OpenRaoSearchTreeParameters;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SweCsaNetworkShifterTest {
 
     @Test
     void testShiftExchangeValues() throws GlskLimitationException, ShiftingException {
         Network network = Network.read("/dichotomy/TestCase_with_swe_countries.xiidm", getClass().getResourceAsStream("/dichotomy/TestCase_with_swe_countries.xiidm"));
+        RaoParameters raoParameters = RaoParameters.load();
         ZonalData<Scalable> scalableZonalData = SweCsaZonalData.getZonalData(network);
         Map<String, Double> targetExchanges = Map.of(
             "ES_FR", 2020.,
@@ -40,7 +44,7 @@ class SweCsaNetworkShifterTest {
         assertEquals(2012., balance.get("ES_FR"), 1);
         assertEquals(0, balance.get("ES_PT"), 1);
 
-        new SweCsaNetworkShifter(scalableZonalData, 2012., 0., new ShiftDispatcher(initialNetPositions)).shiftExchangeValues(network, targetExchanges, scalingValues);
+        new SweCsaNetworkShifter(scalableZonalData, 2012., 0., new ShiftDispatcher(initialNetPositions)).shiftExchangeValues(network, targetExchanges, scalingValues, raoParameters);
         Map<String, Double> newBalance = CountryBalanceComputation.computeSweBordersExchanges(network);
         assertEquals(2020., newBalance.get("ES_FR"), 1);
         assertEquals(0, newBalance.get("ES_PT"), 1);
@@ -50,6 +54,7 @@ class SweCsaNetworkShifterTest {
     @Test
     void testShiftExchangeValuesWithShiftingException() {
         Network network = Network.read("/dichotomy/TestCase_with_swe_countries.xiidm", getClass().getResourceAsStream("/dichotomy/TestCase_with_swe_countries.xiidm"));
+        RaoParameters raoParameters = RaoParameters.load();
         ZonalData<Scalable> scalableZonalData = SweCsaZonalData.getZonalData(network);
         Map<String, Double> targetExchanges = Map.of(
             "ES_FR", 100.0,
@@ -61,7 +66,7 @@ class SweCsaNetworkShifterTest {
             new EICode(Country.ES).getAreaCode(), -500.
         );
         ShiftDispatcher dispatcher = new ShiftDispatcher(Map.of(Country.ES.getName(), -1., Country.FR.getName(), 1., Country.PT.getName(), 2.));
-        assertThrows(ShiftingException.class, () -> new SweCsaNetworkShifter(scalableZonalData, 100., 200., dispatcher).shiftExchangeValues(network, targetExchanges, scalingValues));
+        assertThrows(ShiftingException.class, () -> new SweCsaNetworkShifter(scalableZonalData, 100., 200., dispatcher).shiftExchangeValues(network, targetExchanges, scalingValues, raoParameters));
     }
 
     @Test
@@ -83,5 +88,43 @@ class SweCsaNetworkShifterTest {
         assertEquals(60, scalingValues.get(new EICode(Country.ES).getAreaCode()));
         assertEquals(25.0, scalingValues.get(new EICode(Country.FR).getAreaCode()));
         assertEquals(15.0, scalingValues.get(new EICode(Country.PT).getAreaCode()));
+    }
+
+    @Test
+    void testShiftExchangeValuesWithLfDivergenceException() throws GlskLimitationException, ShiftingException {
+        Network network = Network.read("/dichotomy/TestCase_with_swe_countries.xiidm", getClass().getResourceAsStream("/dichotomy/TestCase_with_swe_countries.xiidm"));
+        ZonalData<Scalable> scalableZonalData = SweCsaZonalData.getZonalData(network);
+        Map<String, Double> targetExchanges = Map.of(
+                "ES_FR", 2020.,
+                "ES_PT", 0.
+        );
+        Map<String, Double> scalingValues = Map.of(
+                new EICode(Country.PT).getAreaCode(), 0.,
+                new EICode(Country.FR).getAreaCode(), -8.,
+                new EICode(Country.ES).getAreaCode(), 8.
+        );
+        ShiftDispatcher dispatcher = new ShiftDispatcher(Map.of(Country.ES.getName(), -1., Country.FR.getName(), 1., Country.PT.getName(), 2.));
+
+        // Network should diverge with these rao parameters: only 1 NR iteration allowed
+        RaoParameters divergingRaoParameters = createRaoAndOlfParameters(new OpenLoadFlowParameters().setMaxNewtonRaphsonIterations(1));
+        assertThrows(ShiftingException.class, () -> new SweCsaNetworkShifter(scalableZonalData, 2012., 0., dispatcher).shiftExchangeValues(network, targetExchanges, scalingValues, divergingRaoParameters));
+
+        // Network should converge with these rao parameters: 10 NR iterations allowed
+        RaoParameters convergingRaoParameters = createRaoAndOlfParameters(new OpenLoadFlowParameters().setMaxNewtonRaphsonIterations(10));
+        new SweCsaNetworkShifter(scalableZonalData, 2012., 0., dispatcher).shiftExchangeValues(network, targetExchanges, scalingValues, convergingRaoParameters);
+        Map<String, Double> newBalance = CountryBalanceComputation.computeSweBordersExchanges(network);
+        assertEquals(2020., newBalance.get("ES_FR"), 1);
+        assertEquals(0, newBalance.get("ES_PT"), 1);
+
+    }
+
+    private static RaoParameters createRaoAndOlfParameters(OpenLoadFlowParameters openLoadFlowParameters) {
+        RaoParameters raoParameters = RaoParameters.load();
+        LoadFlowAndSensitivityParameters loadFlowAndSensitivityParameters = new LoadFlowAndSensitivityParameters();
+        loadFlowAndSensitivityParameters.getSensitivityWithLoadFlowParameters().getLoadFlowParameters().addExtension(OpenLoadFlowParameters.class, openLoadFlowParameters);
+        OpenRaoSearchTreeParameters raoSearchTreeParameters = new OpenRaoSearchTreeParameters();
+        raoSearchTreeParameters.setLoadFlowAndSensitivityParameters(loadFlowAndSensitivityParameters);
+        raoParameters.addExtension(OpenRaoSearchTreeParameters.class, raoSearchTreeParameters);
+        return raoParameters;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
Yes, the issue is described here: https://github.com/farao-community/gridcapa-swe-csa/issues/55


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
A bug fix. LF parameters used in during the net positions shifting are different from the rest of the process. This can lead to divergence in some cases as the default LF parameters are used in the network shifter. 


**What is the current behavior?** *(You can also link to an open issue here)*
Default LF paramaters in the network shifter is leading to LF divergence.


**What is the new behavior (if this is a feature change)?**
The LF parameters provided in the rao parameters are used. 


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No.


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced counter-trading and exchange value calculation methods to accept additional configuration parameters, enabling more flexible and accurate load-flow computations.

* **Tests**
  * Added new test case to validate load-flow divergence behavior under various configuration scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->